### PR TITLE
Geohash in Tracks_data and Tracks_info (firebase)

### DIFF
--- a/app/src/main/java/hpsaturn/pollutionreporter/models/SensorTrack.java
+++ b/app/src/main/java/hpsaturn/pollutionreporter/models/SensorTrack.java
@@ -18,6 +18,7 @@ public class SensorTrack {
     public float kms;
     public double lastLat;
     public double lastLon;
+    public String geohash;
     public SensorData lastSensorData;
     public ArrayList<SensorData> data;
     public String deviceId;

--- a/app/src/main/java/hpsaturn/pollutionreporter/models/SensorTrackInfo.java
+++ b/app/src/main/java/hpsaturn/pollutionreporter/models/SensorTrackInfo.java
@@ -11,6 +11,7 @@ public class SensorTrackInfo {
     private String deviceId;
     private double lastLat;
     private double lastLon;
+    private String geohash;
     private SensorData lastSensorData;
     private int size;
     private float kms;
@@ -27,6 +28,7 @@ public class SensorTrackInfo {
        this.deviceId = track.deviceId;
        this.lastLat = track.lastLat;
        this.lastLon = track.lastLon;
+       this.geohash = track.geohash;
        this.lastSensorData = track.lastSensorData;
     }
 

--- a/app/src/main/java/hpsaturn/pollutionreporter/service/RecordTrackService.java
+++ b/app/src/main/java/hpsaturn/pollutionreporter/service/RecordTrackService.java
@@ -13,6 +13,7 @@ import android.os.IBinder;
 
 import androidx.core.app.NotificationCompat;
 
+import com.fonfon.geohash.GeoHash;
 import com.google.gson.Gson;
 import com.hpsaturn.tools.FileTools;
 import com.hpsaturn.tools.Logger;
@@ -349,6 +350,7 @@ public class RecordTrackService extends Service {
         Logger.i(TAG, "[TRACK] saving record track..");
         SensorTrack lastTrack = getLastTrack();
         Storage.saveTrack(this, lastTrack);
+        Logger.i(TAG,"[TRACK] track: "+new Gson().toJson(lastTrack));
         saveTrackOnSD(lastTrack);
         Storage.setSensorData(this, new ArrayList<>()); // clear sensor data
         recordTrackManager.tracksUpdated();
@@ -379,6 +381,8 @@ public class RecordTrackService extends Service {
             track.lastSensorData = lastSensorData;
             track.lastLat = lastSensorData.lat;
             track.lastLon = lastSensorData.lon;
+            Location lastLocation = SmartLocation.with(this).location().getLastLocation();
+            track.geohash = GeoHash.fromLocation(lastLocation, Config.GEOHASHACCU).toString();
         }
         printTrack(track);
         return track;
@@ -392,6 +396,9 @@ public class RecordTrackService extends Service {
         Logger.i(TAG, "[TRACK] hrs: "+track.hours);
         Logger.i(TAG, "[TRACK] min: "+track.mins);
         Logger.i(TAG, "[TRACK] seg: "+track.secs);
+        Logger.i(TAG, "[TRACK] lat: "+track.lastLat);
+        Logger.i(TAG, "[TRACK] lon: "+track.lastLon);
+        Logger.i(TAG, "[TRACK] geo: "+track.geohash);
     }
 
 

--- a/app/src/main/java/hpsaturn/pollutionreporter/view/ChartFragment.java
+++ b/app/src/main/java/hpsaturn/pollutionreporter/view/ChartFragment.java
@@ -235,7 +235,7 @@ public class ChartFragment extends Fragment {
         for (String type : values) {
             ChartVar var = new ChartVar(getContext(), type, maplabels.get(type));
             variables.add(var);
-            Logger.i(TAG, "[CHART]"+type);
+            Logger.i(TAG, "[CHART] "+type);
         }
 
         requireActivity().runOnUiThread(this::loadData);

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 mCompileSdkVersion=31
 mMinSdkVersion=21
 mTargetSdkVersion=31
-mVersionCode=591
+mVersionCode=592
 mVersionName=0.7.4
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
- [x] added Geohash implementation on track recording service for mobile tracks
- [x] added geohash field in date models (tracks data and tracks info for Firebase)
- [x] in share action save the geohash in the Firebase endpoints (tracks data and info) 
- [x] tested in Android 11